### PR TITLE
dy calculation uses 3cm drift length, comments

### DIFF
--- a/components/display-mapper.js
+++ b/components/display-mapper.js
@@ -14,7 +14,7 @@ export function* mapToDisplayDataFormat(data) {
                 
                 const x1l = layerDim.maxR;
                 const x2l = layerDim.minR;
-                const xr = Math.abs(layerDim.maxR - layerDim.minR);
+                const xr = 3;   // distance over which dy is measured (drift height)
 
                 const y1l = -t.lY;
                 const y2l = -t.lY + (t.dyDx * xr);
@@ -33,10 +33,11 @@ export function* mapToDisplayDataFormat(data) {
                     x1, -y1, z2,
                     x1, -y1, z1
                 ];
-                t.y1 = y1l;
-                t.y2 = y2l;
-                t.y2p = -t.lY + (t.dyDxAP * xr);
-                t.y2n = -t.lY + (t.dyDxAN * xr);
+                t.y1 = y1l;     // both tracklets' start point (top of display)
+                t.y2 = y2l;     // calibrated tracklet end point (bottom of display)
+                t.y2n = -t.lY + (t.dyDxAN * xr);    // raw tracklet end point (bottom)
+
+                t.y2p = -t.lY + (t.dyDxAP * xr);    // not used
 
                 trackletMap.set(t.id, t);
 


### PR DESCRIPTION
Hi @samperumal!

I've made good progress porting your aliroot analysis task to O2 and packaging it as an O2 "workflow". I noticed one thing in the `display-mapper` that did not look correct to me. This is the distance by which to multiply a slope `dydx` in order to get the deflection length `dy`. The deflection length is, by convention, measured over the 3cm drift region. Therefore, `dydx` should be multiplied by 3cm to get `dy`. I think the raw data plots in the event display look more accurate after this change as well.

I also added a few comments to explain what a few of the variables in your code refer to. This was more of a note to myself, but I think it may be useful for anyone else who looks at the code in the future as well.

Let me know your thoughts!