### PR TITLE
Draw 30 time bins, misc. changes.

### DIFF
--- a/components/display-mapper.js
+++ b/components/display-mapper.js
@@ -17,8 +17,14 @@ export function* mapToDisplayDataFormat(data) {
                 const xr = 3;   // distance over which dy is measured (drift height)
 
                 const y1l = -t.lY;
-                const y2l = -t.lY + (t.dyDx * xr);
 
+                // dy (in O2) is given over 3cm drift height. This is not 30 time bins. Currently it is fixed
+                // to ~20 time bins which is determined by vDrift. The event display draws 30 time bins, 
+                // therefore, the slope must be scaled accordingly.
+                const tbScaleFactor = 30 / 20;
+                
+                const y2l = -t.lY + (t.dyDx * tbScaleFactor * xr);
+                
                 const z1 = -(layerDim.minZ + layerDim.zsize * t.row);
                 const z2 = -(layerDim.minZ + layerDim.zsize * (t.row + 1));
                 
@@ -35,7 +41,7 @@ export function* mapToDisplayDataFormat(data) {
                 ];
                 t.y1 = y1l;     // both tracklets' start point (top of display)
                 t.y2 = y2l;     // calibrated tracklet end point (bottom of display)
-                t.y2n = -t.lY + (t.dyDxAN * xr);    // raw tracklet end point (bottom)
+                t.y2n = -t.lY + (t.dyDxAN * tbScaleFactor * xr);    // raw tracklet end point (bottom)
 
                 t.y2p = -t.lY + (t.dyDxAP * xr);    // not used
 

--- a/components/timebin-view.js
+++ b/components/timebin-view.js
@@ -138,7 +138,7 @@ export class TimebinViewComponent extends ComponentBase {
 
                     const ydomain = d3.extent(padBounds);
 
-                    const binydomain = d3.range(25);
+                    const binydomain = d3.range(30);
 
                     location = {
                         stack: trackletData.stk,
@@ -418,9 +418,9 @@ class PadSubView {
             .attr("height", binyscale.bandwidth())
             .style("fill", d => colourScale(d.val));
 
-        this.trackletPath.attr("d", this.tline([[location.y1, 0], [location.y2, 24]]));
+        this.trackletPath.attr("d", this.tline([[location.y1, 0], [location.y2, 29]]));
         //this.trackletPathPos.attr("d", this.tline([[location.y1, 5], [location.y2p, 25]]));
-        this.trackletPathNeg.attr("d", this.tline([[location.y1, 0], [location.y2n, 24]]));
+        this.trackletPathNeg.attr("d", this.tline([[location.y1, 0], [location.y2n, 29]]));
     }
 }
 

--- a/components/track-information.js
+++ b/components/track-information.js
@@ -59,7 +59,7 @@ export class TrackInformationComponent {
             const info = track.i;
 
             track_text = `${track.typ} track ${track.id} traverses Sector ${track.sec}, Stack ${track.stk} of the TRD`;
-            if (info.pT != null) track_text += ` with a transverse momentum of <em>${info.pT} GeV</em>.`; else track_text += ".";
+            if (info.pT != null) track_text += ` with a transverse momentum of <em>${info.pT.toFixed(3)} GeV</em>.`; else track_text += ".";
 
             if (info.pid != null) track_text += `\n\n The calculated PID value of ${info.pid} indicates this is likely <em>${info.pid >= 100 ? "an electron" : "a pion"}</em> track.`;
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <script nomodule src="components/display-mapper.js"></script>
     <script nomodule src="components/timebin-view.js"></script>
     
-    <script src="data/pPb/script.js"></script>
+    <script src="data/o2/script.js"></script>
     
     <title>ALICE TRD Event Display - final version</title>
 


### PR DESCRIPTION
A few changes:

- Digits view now draws 30 time bins. In O2, `dy` is given over the drift region only. To translate this drift height into time bins requires knowledge of the drift velocity. Currently, the drift velocity is fixed to 1.5464 for all calibrated tracklets until calibration is done properly. This number works out to ~20 time bins. Therefore, in order to draw the tracklet over the full range of 30 time bins, we need to scale the deflection by a factor of 30 / 20.
- Displayed data defaults to `data/o2`.
- In the track information panel, track pT is now rounded to 3 decimal places.